### PR TITLE
Potential fix for code scanning alert no. 1: Client-side cross-site scripting

### DIFF
--- a/frontend/src/components/Login.vue
+++ b/frontend/src/components/Login.vue
@@ -2,7 +2,7 @@
   <div>
     <div v-if="hasError" class="uk-alert-danger" uk-alert>
       <a class="uk-alert-close" uk-close></a>
-      <p v-html="error"></p>
+      <p>{{ error }}</p>
     </div>
     <div class="uk-flex uk-flex-center uk-flex-middle uk-text-center">
       <div class="uk-card uk-card-default">


### PR DESCRIPTION
Potential fix for [https://github.com/CloudSinBarreras/ghas-demo/security/code-scanning/1](https://github.com/CloudSinBarreras/ghas-demo/security/code-scanning/1)

To fix this DOM-based XSS vulnerability, the user-supplied `error` parameter must never be rendered directly as HTML. The safest and most straightforward fix is to avoid `v-html` altogether and use plain text binding (i.e., mustache syntax or `v-text`) to render the error message, ensuring it is not interpreted as HTML and any malicious code will only appear as visible text, never executed.

**How to apply the fix:**
- In the template, replace `<p v-html="error"></p>` with `<p>{{ error }}</p>`.
- No other logic changes are required, as Vue's built-in text binding automatically escapes any potentially malicious characters.
- No new imports or dependencies are needed.

Change only the template as shown, within `frontend/src/components/Login.vue`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
